### PR TITLE
Fix checkbox text wrapping

### DIFF
--- a/components/FbxButton/FbxButton.stories.js
+++ b/components/FbxButton/FbxButton.stories.js
@@ -8,7 +8,7 @@ import summary from './FbxButton.md';
 
 const stories = storiesOf('FbxButton', module);
 
-stories.add('Default', withInfo({ summary })(() => ({
+stories.add('default', withInfo({ summary })(() => ({
   components: { FbxButton },
   template: `<fbx-button
                 name="fbx-button"

--- a/components/FbxCheckbox/FbxCheckbox.stories.js
+++ b/components/FbxCheckbox/FbxCheckbox.stories.js
@@ -6,7 +6,7 @@ import { text } from '@storybook/addon-knobs';
 import FbxCheckbox from './FbxCheckbox.vue';
 import summary from './FbxCheckbox.md';
 
-const stories = storiesOf('Checkbox', module);
+const stories = storiesOf('FbxCheckbox', module);
 
 stories.add('simple', withInfo({ summary })(() => ({
   components: { FbxCheckbox },

--- a/components/FbxCheckbox/FbxCheckbox.stories.js
+++ b/components/FbxCheckbox/FbxCheckbox.stories.js
@@ -8,12 +8,15 @@ import summary from './FbxCheckbox.md';
 
 const stories = storiesOf('FbxCheckbox', module);
 
-stories.add('simple', withInfo({ summary })(() => ({
+stories.add('Default', withInfo({ summary })(() => ({
   components: { FbxCheckbox },
   template: `<fbx-checkbox
-                name="foo"
+                name="fbx-checkbox"
+                id="my-id"
+                data-qa="checkbox-qa"
+                tabindex="1"
                 v-model="value"
-              >${text('Text', 'Simple checkbox usage')}</fbx-checkbox>`,
+              >${text('Text', 'Toggle me')}</fbx-checkbox>`,
   data () { return { value: true } },
   watch: {
     value (val) {
@@ -25,7 +28,7 @@ stories.add('simple', withInfo({ summary })(() => ({
 stories.add('with validation', withInfo({ summary })(() => ({
   components: { FbxCheckbox },
   template: `<fbx-checkbox
-                name="foo"
+                name="fbx-checkbox"
                 v-model="value"
                 validations="required"
               >${text('Text', 'Checkbox with required validation')}</fbx-checkbox>`,
@@ -40,7 +43,7 @@ stories.add('with validation', withInfo({ summary })(() => ({
 stories.add('with events', withInfo({ summary })(() => ({
   components: { FbxCheckbox },
   template: `<fbx-checkbox
-                name="foo"
+                name="fbx-checkbox"
                 v-model="value"
                 @click="onClick"
                 @change="onChange"

--- a/components/FbxCheckbox/FbxCheckbox.stories.js
+++ b/components/FbxCheckbox/FbxCheckbox.stories.js
@@ -8,7 +8,7 @@ import summary from './FbxCheckbox.md';
 
 const stories = storiesOf('FbxCheckbox', module);
 
-stories.add('Default', withInfo({ summary })(() => ({
+stories.add('default', withInfo({ summary })(() => ({
   components: { FbxCheckbox },
   template: `<fbx-checkbox
                 name="fbx-checkbox"

--- a/components/FbxCheckbox/FbxCheckbox.stories.js
+++ b/components/FbxCheckbox/FbxCheckbox.stories.js
@@ -25,6 +25,25 @@ stories.add('default', withInfo({ summary })(() => ({
   }
 })));
 
+stories.add('with long, wrapping text', withInfo({ summary })(() => ({
+  components: { FbxCheckbox },
+  template: `<div style="width: 300px; fontSize: 14px; fontWeight: 300;">
+              <fbx-checkbox
+                name="fbx-checkbox"
+                v-model="value"
+                validations="required"
+              >
+                ${text('Text', 'Tiramisu licorice sugar brownie halvah tart caramels. candy chupa chups caramels marzipan. candy canes.')}
+              </fbx-checkbox>
+            </div>`,
+  data () { return { value: true } },
+  watch: {
+    value: function (val) {
+      action(`New value: ${val}`)()
+    },
+  }
+})));
+
 stories.add('with validation', withInfo({ summary })(() => ({
   components: { FbxCheckbox },
   template: `<fbx-checkbox

--- a/components/FbxCheckbox/FbxCheckbox.vue
+++ b/components/FbxCheckbox/FbxCheckbox.vue
@@ -57,12 +57,9 @@ export default {
 <style lang="scss" scoped>
 @import "./../styles/utils/color-palette";
 
-.fbx-checkbox-container {
-  display: inline-block;
-}
-
 .fbx-checkbox {
   position: relative;
+  display: block;
   text-align: left;
   padding-left: 25px;
 
@@ -72,7 +69,7 @@ export default {
     &,
     & + .box {
       position: absolute;
-      top: calc(50% - 8px);
+      top: 2px;
       left: 0;
       height: 16px;
       width: 16px;
@@ -98,10 +95,13 @@ export default {
       border-color: $medium-gray;
     }
   }
+
+  &.invalid {
+    padding-bottom: 10px;
+    border-bottom: 1px solid $light-red;
+  }
 }
 .validation-message {
-  margin-top: 5px;
-  padding-top: 5px;
-  border-top: 1px solid $light-red;
+  padding-top: 10px;
 }
 </style>

--- a/components/FbxCheckbox/FbxCheckbox.vue
+++ b/components/FbxCheckbox/FbxCheckbox.vue
@@ -1,7 +1,16 @@
 <template>
   <div class="fbx-checkbox-container">
     <label class="fbx-checkbox" :class="{invalid: isInvalid}">
-      <input type="checkbox" class="input" v-validate="validations" v-bind="$attrs" :value="value" :checked="value" v-on="listeners" />
+      <input
+        tabindex="0"
+        type="checkbox"
+        class="input"
+        v-validate="validations"
+        v-bind="$attrs"
+        v-on="listeners"
+        :value="value"
+        :checked="value"
+      />
       <span class="box"></span>
       <slot></slot>
     </label>

--- a/components/FbxCheckbox/FbxCheckbox.vue
+++ b/components/FbxCheckbox/FbxCheckbox.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="fbx-checkbox-container">
-    <label class="fbx-checkbox" :class="{invalid: isInvalid}">
+    <label class="fbx-checkbox" :class="{ 'fbx-checkbox-invalid': isInvalid }">
       <input
         tabindex="0"
         type="checkbox"
@@ -96,7 +96,7 @@ export default {
     }
   }
 
-  &.invalid {
+  &.fbx-checkbox-invalid {
     padding-bottom: 10px;
     border-bottom: 1px solid $light-red;
   }

--- a/components/FbxCloseButton/FbxCloseButton.stories.js
+++ b/components/FbxCloseButton/FbxCloseButton.stories.js
@@ -7,7 +7,7 @@ import summary from './FbxCloseButton.md';
 
 const stories = storiesOf('FbxCloseButton', module);
 
-stories.add('Default', withInfo({ summary })(() => ({
+stories.add('default', withInfo({ summary })(() => ({
   components: { FbxCloseButton },
   template: `<fbx-close-button
                 data-qa="close-button"


### PR DESCRIPTION
The checkbox was appearing centered with text if the text wrapped to several lines instead of being next to the first line of text. Now it will look like:

![image](https://user-images.githubusercontent.com/5829188/45457629-c1f8cd00-b6a4-11e8-9258-412bc407f9f9.png)

cc @Fundbox/vue-committee 