### PR TITLE
FbxTextField

### DIFF
--- a/components/FbxButton/FbxButton.stories.js
+++ b/components/FbxButton/FbxButton.stories.js
@@ -6,7 +6,7 @@ import { text, boolean } from '@storybook/addon-knobs';
 import FbxButton from './FbxButton.vue';
 import summary from './FbxButton.md';
 
-const stories = storiesOf('FbxButton', module);
+const stories = storiesOf('Button', module);
 
 stories.add('default', withInfo({ summary })(() => ({
   components: { FbxButton },

--- a/components/FbxButton/FbxButton.vue
+++ b/components/FbxButton/FbxButton.vue
@@ -1,7 +1,7 @@
 <template>
 <button
   tabindex="0"
-  type="submit"
+  type="button"
   class="fbx-cta-button"
   :class="{'fbx-button-inverse': inverse, 'loading': loading }"
   :disabled="loading"

--- a/components/FbxCheckbox/FbxCheckbox.stories.js
+++ b/components/FbxCheckbox/FbxCheckbox.stories.js
@@ -6,7 +6,7 @@ import { text } from '@storybook/addon-knobs';
 import FbxCheckbox from './FbxCheckbox.vue';
 import summary from './FbxCheckbox.md';
 
-const stories = storiesOf('FbxCheckbox', module);
+const stories = storiesOf('Checkbox', module);
 
 stories.add('default', withInfo({ summary })(() => ({
   components: { FbxCheckbox },

--- a/components/FbxCloseButton/FbxCloseButton.stories.js
+++ b/components/FbxCloseButton/FbxCloseButton.stories.js
@@ -5,7 +5,7 @@ import { withInfo } from 'storybook-addon-vue-info';
 import FbxCloseButton from './FbxCloseButton.vue';
 import summary from './FbxCloseButton.md';
 
-const stories = storiesOf('FbxCloseButton', module);
+const stories = storiesOf('CloseButton', module);
 
 stories.add('default', withInfo({ summary })(() => ({
   components: { FbxCloseButton },

--- a/components/FbxTabs/FbxTabs.stories.js
+++ b/components/FbxTabs/FbxTabs.stories.js
@@ -5,7 +5,7 @@ import { array } from '@storybook/addon-knobs';
 
 import FbxTabs from './FbxTabs.vue';
 import summary from './FbxTabs.md';
-const stories = storiesOf('FbxTabs', module);
+const stories = storiesOf('Tabs', module);
 
 stories.add('default', withInfo({ summary })(() => ({
   components: { FbxTabs },

--- a/components/FbxTextField/FbxTextField.md
+++ b/components/FbxTextField/FbxTextField.md
@@ -1,4 +1,4 @@
-# FbxTabs
+# FbxTextField
 
 ## Basic usage
 

--- a/components/FbxTextField/FbxTextField.md
+++ b/components/FbxTextField/FbxTextField.md
@@ -2,9 +2,16 @@
 
 ## Basic usage
 
-- Use 1
-- Use 2
+- Cool description
 
 ```html
-<fbx-text-field />
+<fbx-text-field
+  name="email"
+  class="input"
+  validations="required|email"
+  placeholder="Enter your email address"
+  :label="'Email Address'"
+  v-model.trim="email"
+  data-qa="login-email"
+/>
 ```

--- a/components/FbxTextField/FbxTextField.md
+++ b/components/FbxTextField/FbxTextField.md
@@ -1,0 +1,10 @@
+# FbxTabs
+
+## Basic usage
+
+- Use 1
+- Use 2
+
+```html
+<fbx-text-field />
+```

--- a/components/FbxTextField/FbxTextField.md
+++ b/components/FbxTextField/FbxTextField.md
@@ -2,16 +2,18 @@
 
 ## Basic usage
 
-- Cool description
+- Use `FbxTextField` for inputs of common types, e.g. `type="text"`, `type="email"`. If your input type isn't supported, open up a PR to add support for that input type
+- The default `type` is `text`, if you don't provide one
 
 ```html
+<!-- Example Usage -->
 <fbx-text-field
   name="email"
-  class="input"
+  class="email-field"
   validations="required|email"
   placeholder="Enter your email address"
   :label="'Email Address'"
   v-model.trim="email"
-  data-qa="login-email"
+  data-qa="my-email-qa"
 />
 ```

--- a/components/FbxTextField/FbxTextField.stories.js
+++ b/components/FbxTextField/FbxTextField.stories.js
@@ -29,3 +29,27 @@ stories.add('default', withInfo({ summary })(() => ({
               v-model="inputText"
             />`,
 })));
+
+stories.add('password', withInfo({ summary })(() => ({
+  components: { FbxTextField },
+  data() {
+    return {
+      inputText: "",
+      labelText: text("Label", "Password"),
+    }
+  },
+  watch: {
+    inputText(value) {
+      action(`New value: ${value}`)()
+    },
+  },
+  template: `<fbx-text-field
+              name="password"
+              type="password"
+              class="input"
+              validations="required"
+              placeholder="Enter your password"
+              :label="labelText"
+              v-model="inputText"
+            />`,
+})));

--- a/components/FbxTextField/FbxTextField.stories.js
+++ b/components/FbxTextField/FbxTextField.stories.js
@@ -1,0 +1,19 @@
+import { storiesOf } from '@storybook/vue';
+import { action } from '@storybook/addon-actions';
+import { withInfo } from 'storybook-addon-vue-info';
+import { array } from '@storybook/addon-knobs';
+
+import FbxTextField from './FbxTextField.vue';
+import summary from './FbxTextField.md';
+const stories = storiesOf('FbxTextField', module);
+
+stories.add('default', withInfo({ summary })(() => ({
+  components: { FbxTextField },
+  data() {
+    return {
+      // tabs: array('Tabs', ['Settings', 'Profile']),
+    }
+  },
+  template: `<fbx-text-field />`,
+  // methods: { onTabSelect: action('onTabSelect') },
+})));

--- a/components/FbxTextField/FbxTextField.stories.js
+++ b/components/FbxTextField/FbxTextField.stories.js
@@ -20,17 +20,19 @@ stories.add('default', withInfo({ summary })(() => ({
       action(`New value: ${value}`)()
     },
   },
-  template: `<fbx-text-field
-              name="email"
-              class="input"
-              validations="required"
-              placeholder="Enter your email"
-              :label="labelText"
-              v-model="inputText"
-            />`,
+  template: `
+    <fbx-text-field
+      name="email"
+      class="input"
+      validations="required"
+      placeholder="Enter your email"
+      :label="labelText"
+      v-model="inputText"
+    />
+  `,
 })));
 
-stories.add('password', withInfo({ summary })(() => ({
+stories.add('password', () => ({
   components: { FbxTextField },
   data() {
     return {
@@ -43,13 +45,17 @@ stories.add('password', withInfo({ summary })(() => ({
       action(`New value: ${value}`)()
     },
   },
-  template: `<fbx-text-field
-              name="password"
-              type="password"
-              class="input"
-              validations="required"
-              placeholder="Enter your password"
-              :label="labelText"
-              v-model="inputText"
-            />`,
-})));
+  template: `
+    <div style="width: 300px; padding: 30px;">
+      <fbx-text-field
+        name="password"
+        type="password"
+        class="input"
+        validations="required"
+        placeholder="Enter your password"
+        :label="labelText"
+        v-model="inputText"
+      />
+    </div>
+  `,
+}));

--- a/components/FbxTextField/FbxTextField.stories.js
+++ b/components/FbxTextField/FbxTextField.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from '@storybook/vue';
 import { action } from '@storybook/addon-actions';
 import { withInfo } from 'storybook-addon-vue-info';
-import { array } from '@storybook/addon-knobs';
+import { text } from '@storybook/addon-knobs';
 
 import FbxTextField from './FbxTextField.vue';
 import summary from './FbxTextField.md';
@@ -11,9 +11,21 @@ stories.add('default', withInfo({ summary })(() => ({
   components: { FbxTextField },
   data() {
     return {
-      // tabs: array('Tabs', ['Settings', 'Profile']),
+      inputText: "",
+      labelText: text("Label", "Email Address"),
     }
   },
-  template: `<fbx-text-field />`,
-  // methods: { onTabSelect: action('onTabSelect') },
+  watch: {
+    inputText(value) {
+      action(`New value: ${value}`)()
+    },
+  },
+  template: `<fbx-text-field
+              name="email"
+              class="input"
+              validations="required"
+              placeholder="Enter your email"
+              :label="labelText"
+              v-model="inputText"
+            />`,
 })));

--- a/components/FbxTextField/FbxTextField.stories.js
+++ b/components/FbxTextField/FbxTextField.stories.js
@@ -5,7 +5,7 @@ import { text } from '@storybook/addon-knobs';
 
 import FbxTextField from './FbxTextField.vue';
 import summary from './FbxTextField.md';
-const stories = storiesOf('FbxTextField', module);
+const stories = storiesOf('TextField', module);
 
 stories.add('default', withInfo({ summary })(() => ({
   components: { FbxTextField },

--- a/components/FbxTextField/FbxTextField.vue
+++ b/components/FbxTextField/FbxTextField.vue
@@ -91,7 +91,7 @@ export default {
 
   .fbx-text-field__input {
     display: block;
-    width: inherit;
+    width: 100%;
     height: 50px;
     min-width: 240px;
     padding: 15px;

--- a/components/FbxTextField/FbxTextField.vue
+++ b/components/FbxTextField/FbxTextField.vue
@@ -104,12 +104,12 @@ export default {
     }
 
     &:focus {
-      border-bottom: 2px solid $dark-green;
+      border-bottom: 1px solid $dark-green;
     }
 
     &.invalid {
       background-color: $extra-light-red;
-      border-bottom: 2px solid $light-red;
+      border-bottom: 1px solid $light-red;
     }
   }
 

--- a/components/FbxTextField/FbxTextField.vue
+++ b/components/FbxTextField/FbxTextField.vue
@@ -1,0 +1,89 @@
+<template>
+  <div class="fbx-text-field">
+    <label class="fbx-text-field__label">{{ label }}</label>
+
+    <input
+      :type="type"
+      v-validate="validations"
+      class="fbx-text-field__input"
+      :class="{ invalid: isInvalid }"
+      v-bind="$attrs"
+      :value="value"
+      @input="onInput"
+      @change="onChange"
+    />
+
+    <fbx-validation-message class="validation-message" v-if="isInvalid">{{ validationMessage }}</fbx-validation-message>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "FbxTextField",
+  inheritAttrs: false,
+  inject: ["$validator"],
+  data() {
+    return {
+      type: this.$attrs.type || "text",
+    }
+  },
+  props: {
+    label: String,
+    value: String,
+    validations: String,
+  },
+  computed: {
+    isInvalid() {
+      return this.errors.has(this.$attrs.name)
+    },
+    validationMessage() {
+      return this.errors.first(this.$attrs.name)
+    }
+  },
+  methods: {
+    onInput(event) {
+      this.$emit("input", event.target.value)
+      // this.$forceUpdate()
+    },
+    onChange(event) {
+      this.$emit("change", event.target.value)
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+@import "./../styles/utils/color-palette";
+@import "./../styles/utils/mixins";
+
+.fbx-text-field {
+  .fbx-text-field__label {
+    @include font(10);
+  }
+
+  .fbx-text-field__input {
+    width: inherit;
+    height: 50px;
+    min-width: 240px;
+    padding: 15px;
+    @include font(16);
+    border-radius: 3px;
+    border: none;
+    background-color: $extra-light-gray;
+    outline: none;
+
+    &:focus {
+      border-bottom: 2px solid $dark-green;
+    }
+
+    &.invalid {
+      background-color: $extra-light-red;
+      border-bottom: 2px solid $light-red;
+    }
+  }
+
+  .validation-message {
+    margin-top: 10px;
+  }
+}
+</style>

--- a/components/FbxTextField/FbxTextField.vue
+++ b/components/FbxTextField/FbxTextField.vue
@@ -2,19 +2,21 @@
   <div class="fbx-text-field">
     <label class="fbx-text-field__label">{{ label }}</label>
 
-    <input
-      :type="type"
-      tabindex="0"
-      class="fbx-text-field__input"
-      :class="{ password: isPassword, invalid: isInvalid }"
-      v-validate="validations"
-      v-bind="$attrs"
-      :value="value"
-      @input="onInput"
-      @change="onChange"
-    />
+    <div class="fbx-text-field__input-wrapper">
+      <input
+        :type="type"
+        tabindex="0"
+        class="fbx-text-field__input"
+        :class="{ password: isPassword, invalid: isInvalid }"
+        v-validate="validations"
+        v-bind="$attrs"
+        :value="value"
+        @input="onInput"
+        @change="onChange"
+      />
 
-    <span class="fbx-text-field__password-button" @click="togglePassword" v-if="isPassword">{{ passwordButtonText }}</span>
+      <span class="fbx-text-field__password-button" @click="togglePassword" v-if="isPassword">{{ passwordButtonText }}</span>
+    </div>
 
     <fbx-validation-message class="validation-message" v-if="isInvalid">{{ validationMessage }}</fbx-validation-message>
   </div>
@@ -82,6 +84,10 @@ export default {
     @include font(16);
   }
 
+  .fbx-text-field__input-wrapper {
+    position: relative;
+  }
+
   .fbx-text-field__input {
     display: block;
     width: inherit;
@@ -111,7 +117,8 @@ export default {
   .fbx-text-field__password-button {
     position: absolute;
     right: 15px;
-    top: 13px;
+    top: 50%;
+    transform: translateY(-50%);
     color: $dark-green;
     @include font(16);
     cursor: pointer;

--- a/components/FbxTextField/FbxTextField.vue
+++ b/components/FbxTextField/FbxTextField.vue
@@ -79,7 +79,7 @@ export default {
 
   .fbx-text-field__label {
     display: block;
-    margin-bottom: 16px;
+    margin-bottom: 7px;
     @include font(16);
   }
 

--- a/components/FbxTextField/FbxTextField.vue
+++ b/components/FbxTextField/FbxTextField.vue
@@ -85,6 +85,7 @@ export default {
 
   .fbx-text-field__input-wrapper {
     position: relative;
+    margin-bottom: 22px;
   }
 
   .fbx-text-field__input {

--- a/components/FbxTextField/FbxTextField.vue
+++ b/components/FbxTextField/FbxTextField.vue
@@ -6,7 +6,7 @@
       :type="type"
       tabindex="0"
       class="fbx-text-field__input"
-      :class="{ invalid: isInvalid }"
+      :class="{ password: isPassword, invalid: isInvalid }"
       v-validate="validations"
       v-bind="$attrs"
       :value="value"
@@ -14,17 +14,25 @@
       @change="onChange"
     />
 
+    <span class="fbx-text-field__password-button" @click="togglePassword" v-if="isPassword">{{ passwordButtonText }}</span>
+
     <fbx-validation-message class="validation-message" v-if="isInvalid">{{ validationMessage }}</fbx-validation-message>
   </div>
 </template>
 
 <script>
+import FbxValidationMessage from "../FbxValidationMessage/FbxValidationMessage.vue"
+
 export default {
   name: "FbxTextField",
+  components: {
+    FbxValidationMessage,
+  },
   inheritAttrs: false,
   inject: ["$validator"],
   data() {
     return {
+      isPassword: this.$attrs.type === "password",
       type: this.$attrs.type || "text",
     }
   },
@@ -34,6 +42,9 @@ export default {
     validations: String,
   },
   computed: {
+    passwordButtonText() {
+      return this.isPassword && this.type === "text" ? "Hide" : "Show";
+    },
     isInvalid() {
       return this.errors.has(this.$attrs.name)
     },
@@ -42,9 +53,12 @@ export default {
     }
   },
   methods: {
+    togglePassword() {
+      this.type = this.type === "password" ? "text" : "password";
+    },
     onInput(event) {
       this.$emit("input", event.target.value)
-      // this.$forceUpdate()
+      this.$forceUpdate()
     },
     onChange(event) {
       this.$emit("change", event.target.value)
@@ -58,6 +72,10 @@ export default {
 @import "./../styles/utils/mixins";
 
 .fbx-text-field {
+  position: relative;
+  display: inline-block;
+  width: 100%;
+
   .fbx-text-field__label {
     display: block;
     margin-bottom: 16px;
@@ -71,10 +89,14 @@ export default {
     min-width: 240px;
     padding: 15px;
     @include font(16);
-    border-radius: 3px;
     border: none;
+    color: $medium-blue;
     background-color: $extra-light-gray;
     outline: none;
+
+    &.password {
+      padding-right: 60px;
+    }
 
     &:focus {
       border-bottom: 2px solid $dark-green;
@@ -84,6 +106,16 @@ export default {
       background-color: $extra-light-red;
       border-bottom: 2px solid $light-red;
     }
+  }
+
+  .fbx-text-field__password-button {
+    position: absolute;
+    right: 15px;
+    top: 13px;
+    color: $dark-green;
+    @include font(16);
+    cursor: pointer;
+    user-select: none;
   }
 
   .validation-message {

--- a/components/FbxTextField/FbxTextField.vue
+++ b/components/FbxTextField/FbxTextField.vue
@@ -16,9 +16,9 @@
       />
 
       <span class="fbx-text-field__password-button" @click="togglePassword" v-if="isPassword">{{ passwordButtonText }}</span>
-    </div>
 
-    <fbx-validation-message class="validation-message" v-if="isInvalid">{{ validationMessage }}</fbx-validation-message>
+      <fbx-validation-message class="validation-message" v-if="isInvalid">{{ validationMessage }}</fbx-validation-message>
+    </div>
   </div>
 </template>
 

--- a/components/FbxTextField/FbxTextField.vue
+++ b/components/FbxTextField/FbxTextField.vue
@@ -40,7 +40,7 @@ export default {
   },
   props: {
     label: String,
-    value: String,
+    value: [String, Number],
     validations: String,
   },
   computed: {

--- a/components/FbxTextField/FbxTextField.vue
+++ b/components/FbxTextField/FbxTextField.vue
@@ -59,10 +59,13 @@ export default {
 
 .fbx-text-field {
   .fbx-text-field__label {
-    @include font(10);
+    display: block;
+    margin-bottom: 16px;
+    @include font(16);
   }
 
   .fbx-text-field__input {
+    display: block;
     width: inherit;
     height: 50px;
     min-width: 240px;

--- a/components/FbxTextField/FbxTextField.vue
+++ b/components/FbxTextField/FbxTextField.vue
@@ -60,7 +60,6 @@ export default {
     },
     onInput(event) {
       this.$emit("input", event.target.value)
-      this.$forceUpdate()
     },
     onChange(event) {
       this.$emit("change", event.target.value)

--- a/components/FbxTextField/FbxTextField.vue
+++ b/components/FbxTextField/FbxTextField.vue
@@ -4,9 +4,10 @@
 
     <input
       :type="type"
-      v-validate="validations"
+      tabindex="0"
       class="fbx-text-field__input"
       :class="{ invalid: isInvalid }"
+      v-validate="validations"
       v-bind="$attrs"
       :value="value"
       @input="onInput"

--- a/components/FbxTextField/FbxTextField.vue
+++ b/components/FbxTextField/FbxTextField.vue
@@ -80,7 +80,8 @@ export default {
   .fbx-text-field__label {
     display: block;
     margin-bottom: 7px;
-    @include font(16);
+    color: $extra-dark-gray;
+    @include font(16, light);
   }
 
   .fbx-text-field__input-wrapper {

--- a/components/main.stories.js
+++ b/components/main.stories.js
@@ -5,3 +5,4 @@ import FbxButtonStories from './FbxButton/FbxButton.stories.js';
 import FbxCheckboxStories from './FbxCheckbox/FbxCheckbox.stories.js';
 import FbxCloseButtonStories from './FbxCloseButton/FbxCloseButton.stories.js';
 import FbxTabs from './FbxTabs/FbxTabs.stories.js';
+import FbxTextField from './FbxTextField/FbxTextField.stories.js';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fundbox-ui",
-  "version": "0.0.2",
+  "version": "0.2.0",
   "description": "Fundbox UI Components Library",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description
- [x] Rename stories list from `FbxComponent` to `Component`
- [x] Add `FbxTextField` (borrowed heavily from @forforeach's work in the checkout web app 🙇)
- [x] Remove `floatl` library for labels since dashboard code isn't using that design 😢Potentially in the future we can allow for both
- [x] Make sure simple validations work
- [x] Use `type="button"` as the default for `FbxButton` instead of `type="submit"`