### PR TITLE
Fix display bug for textInput

### DIFF
--- a/components/FbxTextField/FbxTextField.vue
+++ b/components/FbxTextField/FbxTextField.vue
@@ -2,21 +2,23 @@
   <div class="fbx-text-field">
     <label class="fbx-text-field__label">{{ label }}</label>
 
-    <div class="fbx-text-field__input-wrapper">
-      <input
-        :type="type"
-        tabindex="0"
-        class="fbx-text-field__input"
-        :class="{ password: isPassword, invalid: isInvalid }"
-        v-validate="validations"
-        v-bind="$attrs"
-        :value="value"
-        @input="onInput"
-        @change="onChange"
-      />
+    <div class="fbx-text-field__wrapper">
+      <div class="fbx-text-field__input-wrapper">
+        <input
+          :type="type"
+          tabindex="0"
+          class="fbx-text-field__input"
+          :class="{ password: isPassword, invalid: isInvalid }"
+          v-validate="validations"
+          v-bind="$attrs"
+          :value="value"
+          @input="onInput"
+          @change="onChange"
+        />
 
-      <span class="fbx-text-field__password-button" @click="togglePassword" v-if="isPassword">{{ passwordButtonText }}</span>
+        <span class="fbx-text-field__password-button" @click="togglePassword" v-if="isPassword">{{ passwordButtonText }}</span>
 
+      </div>
       <fbx-validation-message class="validation-message" v-if="isInvalid">{{ validationMessage }}</fbx-validation-message>
     </div>
   </div>
@@ -84,9 +86,12 @@ export default {
     @include font(16, light);
   }
 
+  .fbx-text-field__wrapper {
+    margin-bottom: 22px;
+  }
+
   .fbx-text-field__input-wrapper {
     position: relative;
-    margin-bottom: 22px;
   }
 
   .fbx-text-field__input {


### PR DESCRIPTION
The label for show password would break when error massage appears

### before:
<img width="378" alt="screen shot 2018-10-15 at 3 09 14 pm" src="https://user-images.githubusercontent.com/3458336/46950209-a9f1e000-d08c-11e8-9989-cc98cc0c98ad.png">

### after:
<img width="346" alt="screen shot 2018-10-15 at 3 08 53 pm" src="https://user-images.githubusercontent.com/3458336/46950208-a9f1e000-d08c-11e8-8e72-42d1c9ad29d7.png">

