### PR TITLE
feat(infra): scaffolding for different types of elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# Fundbox UI Components
+# Fundbox UI
+
+
+## Development
+
+### Scaffolding
+In order to improve productivity you can generate new elements' structure with CLI commands. We use [hygen](http://www.hygen.io/) for this porpouse. There are couple of ways to use `hygen`:
+1. `npm i -g hygen` - which installs `hygen` globally
+2. `npx hygen ...` - which runs hygen remotly
+
+Available scaffolding types:
+- **Components** - will generate component structure and register it to stories. Also, prefixes the given name with `Fbx`
+  >Usage: `npx hygen component new --name ComponentName`
+
+- **Directives** - will generate directive structure and register it to stories. Also, prefixes the given name with `Fbx`
+  >Usage: `npx hygen directive new --name ComponentName`

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 ## Development
 
 ### Scaffolding
-In order to improve productivity you can generate new elements' structure with CLI commands. We use [hygen](http://www.hygen.io/) for this porpouse. There are couple of ways to use `hygen`:
+In order to improve productivity you can generate new elements' structure with CLI commands. We use [hygen](http://www.hygen.io/) for this purpose. There are couple of ways to use `hygen`:
 1. `npm i -g hygen` - which installs `hygen` globally
-2. `npx hygen ...` - which runs hygen remotly
+2. `npx hygen ...` - which runs `hygen` remotely
 
 Available scaffolding types:
 - **Components** - will generate component structure and register it to stories. Also, prefixes the given name with `Fbx`

--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Available scaffolding types:
   >Usage: `npx hygen component new --name ComponentName`
 
 - **Directives** - will generate directive structure and register it to stories. Also, prefixes the given name with `Fbx`
-  >Usage: `npx hygen directive new --name ComponentName`
+  >Usage: `npx hygen directive new --name DirectiveName`

--- a/_templates/component/new/component.ejs.t
+++ b/_templates/component/new/component.ejs.t
@@ -1,0 +1,15 @@
+---
+to: components/Fbx<%= name %>/Fbx<%= name %>.vue
+---
+<template>
+  <div>Hello from Fbx<%= name %>!</div>
+</template>
+
+<script>
+export default {
+  name: "Fbx<%= name %>"
+};
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/_templates/component/new/component.md.ejs.t
+++ b/_templates/component/new/component.md.ejs.t
@@ -1,0 +1,4 @@
+---
+to: components/Fbx<%= name %>/Fbx<%= name %>.md
+---
+# Fbx<%= name %>

--- a/_templates/component/new/component.spec.ejs.t
+++ b/_templates/component/new/component.spec.ejs.t
@@ -1,0 +1,16 @@
+---
+to: components/Fbx<%= name %>/Fbx<%= name %>.spec.js
+---
+import { shallowMount } from "@vue/test-utils"
+import Fbx<%= name %> from "../Fbx<%= name %>"
+
+describe("Components/Fbx<%= name %>", () => {
+  describe("snapshots", () => {
+    it("renders the default correctly", () => {
+      const wrapper = shallowMount(Fbx<%= name %>, {
+        // mounting options https://vue-test-utils.vuejs.org/api/options.html
+      });
+      expect(wrapper.html()).toMatchSnapshot();
+    });
+  });
+});

--- a/_templates/component/new/component.stories.ejs.t
+++ b/_templates/component/new/component.stories.ejs.t
@@ -1,7 +1,6 @@
 ---
 to: components/Fbx<%= name %>/Fbx<%= name %>.stories.js
 ---
-
 import { storiesOf } from '@storybook/vue';
 import { withInfo } from 'storybook-addon-vue-info';
 

--- a/_templates/component/new/component.stories.ejs.t
+++ b/_templates/component/new/component.stories.ejs.t
@@ -1,0 +1,16 @@
+---
+to: components/Fbx<%= name %>/Fbx<%= name %>.stories.js
+---
+
+import { storiesOf } from '@storybook/vue';
+import { withInfo } from 'storybook-addon-vue-info';
+
+import Fbx<%= name %> from './Fbx<%= name %>.vue';
+import summary from './Fbx<%= name %>.md';
+
+const stories = storiesOf('Components/<%= name %>', module);
+
+stories.add('default', withInfo({ summary })(() => ({
+  components: { Fbx<%= name %> },
+  template: `<fbx-<%= h.inflection.transform(name, [ 'underscore', 'dasherize' ])%>></fbx-<%= h.inflection.transform(name, [ 'underscore', 'dasherize' ])%>>`
+})));

--- a/_templates/component/new/index.ejs.t
+++ b/_templates/component/new/index.ejs.t
@@ -1,0 +1,7 @@
+---
+to: components/Fbx<%= name %>/index.js
+---
+import Vue from "vue";
+import Fbx<%= name %> from "./Fbx<%= name %>.vue";
+Vue.component(Fbx<%= name %>.name, Fbx<%= name %>);
+export default Fbx<%= name %>;

--- a/_templates/component/new/inject_component.ejs.t
+++ b/_templates/component/new/inject_component.ejs.t
@@ -1,0 +1,7 @@
+---
+inject: true
+to: main.stories.js
+skip_if: <%= name %>
+after: "// Components"
+---
+import Fbx<%= name %> from './components/Fbx<%= name %>/Fbx<%= name %>.stories.js';

--- a/_templates/directive/new/directive.ejs.t
+++ b/_templates/directive/new/directive.ejs.t
@@ -1,0 +1,10 @@
+---
+to: directives/Fbx<%= name %>/Fbx<%= name %>.js
+---
+import Vue from "vue";
+
+export default Vue.directive("Fbx<%= name %>", {
+  inserted(el, { value }) {
+    // Make some magic here!
+  }
+});

--- a/_templates/directive/new/directive.md.ejs.t
+++ b/_templates/directive/new/directive.md.ejs.t
@@ -1,0 +1,4 @@
+---
+to: directives/Fbx<%= name %>/Fbx<%= name %>.md
+---
+# Fbx<%= name %>

--- a/_templates/directive/new/directive.spec.ejs.t
+++ b/_templates/directive/new/directive.spec.ejs.t
@@ -1,0 +1,15 @@
+---
+to: directives/Fbx<%= name %>/Fbx<%= name %>.spec.js
+---
+import { shallowMount } from "@vue/test-utils"
+import Fbx<%= name %> from "../Fbx<%= name %>"
+
+describe("Directives/Fbx<%= name %>", () => {
+  it("works", () => {
+    const wrapper = shallowMount({
+      template: "<div v-fbx-<%= h.inflection.transform(name, [ 'underscore', 'dasherize' ])%>></div>",
+    });
+
+    expect(wrapper).toBeTruthy;
+  });
+});

--- a/_templates/directive/new/directive.stories.ejs.t
+++ b/_templates/directive/new/directive.stories.ejs.t
@@ -1,7 +1,6 @@
 ---
 to: directives/Fbx<%= name %>/Fbx<%= name %>.stories.js
 ---
-
 import { storiesOf } from '@storybook/vue';
 import { withInfo } from 'storybook-addon-vue-info';
 

--- a/_templates/directive/new/directive.stories.ejs.t
+++ b/_templates/directive/new/directive.stories.ejs.t
@@ -1,0 +1,16 @@
+---
+to: directives/Fbx<%= name %>/Fbx<%= name %>.stories.js
+---
+
+import { storiesOf } from '@storybook/vue';
+import { withInfo } from 'storybook-addon-vue-info';
+
+import Fbx<%= name %> from './Fbx<%= name %>.js';
+import summary from './Fbx<%= name %>.md';
+
+const stories = storiesOf('Directives/<%= name %>', module);
+
+stories.add('default', withInfo({ summary })(() => ({
+  directives: { Fbx<%= name %> },
+  template: `<div v-fbx-<%= h.inflection.transform(name, [ 'underscore', 'dasherize' ])%>></div>`
+})));

--- a/_templates/directive/new/index.ejs.t
+++ b/_templates/directive/new/index.ejs.t
@@ -1,0 +1,7 @@
+---
+to: directives/Fbx<%= name %>/index.js
+---
+import Vue from "vue";
+import Fbx<%= name %> from "./Fbx<%= name %>.js";
+Vue.directive(Fbx<%= name %>.name, Fbx<%= name %>);
+export default Fbx<%= name %>;

--- a/_templates/directive/new/inject_directive.ejs.t
+++ b/_templates/directive/new/inject_directive.ejs.t
@@ -1,0 +1,7 @@
+---
+inject: true
+to: main.stories.js
+skip_if: <%= name %>
+after: "// Directives"
+---
+import Fbx<%= name %> from './directives/Fbx<%= name %>/Fbx<%= name %>.stories.js';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fundbox-ui",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Fundbox UI Components Library",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Add an ability to generate different types of elements, including full structure and story registration.
Currently available scaffolding types:
- **Components** - will generate component structure and register it to stories. Also, prefixes the given name with `Fbx`
  >Usage: `npx hygen component new --name ComponentName`

- **Directives** - will generate directive structure and register it to stories. Also, prefixes the given name with `Fbx`
  >Usage: `npx hygen directive new --name DirectiveName`

**cc**: @Fundbox/vue-committee 