### PR TITLE
Fix build 

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,9 +126,6 @@
     "v-mask": "^1.3.3",
     "vue-js-modal": "^1.3.27"
   },
-  "publishConfig": {
-    "access": "public"
-  },
   "release": {
     "branch": "refs/heads/master",
     "ci": false

--- a/scripts/webpack.config.build.js
+++ b/scripts/webpack.config.build.js
@@ -36,6 +36,7 @@ module.exports = (elementName, elementType = '', outputDirectory = 'dist') => ({
     alias: {
       vue: 'vue/dist/vue.js',
     },
+    extensions: ['.js', '.json', '.vue']
   },
   module: {
     rules: [


### PR DESCRIPTION
### Description
Build needs to have default extensions (like storybook build) to know how to find `.vue` and `.json` files.
