### PR TITLE
Add editable ability to FbxTextField

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -25,7 +25,13 @@ Developing for the UI library is done within the UI repository alone, as a Story
 
 Once the component is ready for deploy, you'd probably want to implement it within a front-end application to make sure that it fits and works as planned. Our front-end applications are installing the UI library from our [remote npm registry](https://www.npmjs.com/package/@fundbox/ui) so in-order to test the local version of the UI library you'd have to install your local version, located at `~/fundbox/ui`.
 
-To use the local ui package, run:
+To use the local version of the UI library, compile it with your current changes:
+```bash
+cd ~/fundbox/ui
+npm run build:lib
+```
+
+then, run:
 ```bash
 cd ~/fundbox/frontend
 npm run link:ui

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fundbox/ui",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/FbxTextField/FbxTextField.md
+++ b/src/components/FbxTextField/FbxTextField.md
@@ -64,3 +64,14 @@
   currency
 />
 ```
+
+<!-- Example Usage with editable field -->
+<fbx-text-field
+  validations="required"
+  name="word"
+  class="input"
+  placeholder="Enter a word"
+  v-model="inputText"
+  editable
+/>
+```

--- a/src/components/FbxTextField/FbxTextField.spec.js
+++ b/src/components/FbxTextField/FbxTextField.spec.js
@@ -8,6 +8,7 @@ describe('FbxTextField', () => {
   describe('snapshots', () => {
     it('renders the default', () => {
       const wrapper = shallowMount(FbxTextField, {
+        sync: false,
         propsData: {
           name: 'my-input',
           value: 'avocado',
@@ -20,6 +21,7 @@ describe('FbxTextField', () => {
 
     it('renders clear icon', () => {
       const wrapper = shallowMount(FbxTextField, {
+        sync: false,
         propsData: {
           name: 'my-input',
           value: 'avocado',
@@ -33,9 +35,7 @@ describe('FbxTextField', () => {
       expect(wrapper.html()).toMatchSnapshot()
     })
 
-    // TODO(nlitwin): test currently broken due to sync bug
-    // https://github.com/vuejs/vue-test-utils/issues/829
-    it.skip('renders a currency mask', (done) => {
+    it('renders a currency mask', () => {
       const wrapper = shallowMount(FbxTextField, {
         sync: false,
         propsData: {
@@ -44,10 +44,8 @@ describe('FbxTextField', () => {
           currency: true,
         },
       })
-      wrapper.vm.$nextTick(() => {
-        expect(wrapper.html()).toMatchSnapshot()
-        done()
-      })
+
+      expect(wrapper.html()).toMatchSnapshot()
     })
   })
 
@@ -55,6 +53,7 @@ describe('FbxTextField', () => {
     describe('togglePassword', () => {
       it('changes the input type from password to text', () => {
         const wrapper = shallowMount(FbxTextField, {
+          sync: false,
           propsData: {
             name: 'my-input',
             value: 'avocado',
@@ -75,6 +74,7 @@ describe('FbxTextField', () => {
 
       it('changes the input type from text to password', () => {
         const wrapper = shallowMount(FbxTextField, {
+          sync: false,
           propsData: {
             name: 'my-input',
             value: 'avocado',
@@ -93,6 +93,7 @@ describe('FbxTextField', () => {
       it('emits an input event with an empty string', () => {
         const mockOnInput = jest.fn()
         const wrapper = shallowMount(FbxTextField, {
+          sync: false,
           propsData: {
             name: 'my-input',
             value: '42',
@@ -109,10 +110,8 @@ describe('FbxTextField', () => {
       })
     })
 
-    // TODO(nlitwin): test currently broken due to sync bug
-    // https://github.com/vuejs/vue-test-utils/issues/829
     describe('onCurrencyInput', () => {
-      it.skip('emits the change event with the input value', () => {
+      it('emits the change event with the input value', () => {
         const mockOnInput = jest.fn()
         const wrapper = shallowMount(FbxTextField, {
           sync: false,
@@ -129,7 +128,7 @@ describe('FbxTextField', () => {
         wrapper.find('input').trigger('input')
 
         expect(mockOnInput).toHaveBeenCalled()
-        expect(mockOnInput).toHaveBeenCalledWith('12,879.25')
+        expect(mockOnInput).toHaveBeenCalledWith('12879.25')
       })
     })
 
@@ -137,6 +136,7 @@ describe('FbxTextField', () => {
       it('emits the change event with the input value', () => {
         const mockOnInput = jest.fn()
         const wrapper = shallowMount(FbxTextField, {
+          sync: false,
           propsData: {
             name: 'my-input',
             value: '42',
@@ -157,6 +157,7 @@ describe('FbxTextField', () => {
       it('emits the change event with the input value', () => {
         const mockOnChange = jest.fn()
         const wrapper = shallowMount(FbxTextField, {
+          sync: false,
           propsData: {
             name: 'my-input',
             value: '42',

--- a/src/components/FbxTextField/FbxTextField.stories.js
+++ b/src/components/FbxTextField/FbxTextField.stories.js
@@ -201,6 +201,31 @@ const currencyStory = () => ({
   `,
 })
 
+const editableStory = () => ({
+  components: { FbxTextField },
+  data() {
+    return {
+      inputText: '',
+    }
+  },
+  watch: {
+    inputText(value) {
+      action(`New value`)(value)
+    },
+  },
+  template: `
+    <div style="width: 400px;">
+      <fbx-text-field
+        name="word"
+        class="input"
+        placeholder="Enter a word"
+        v-model="inputText"
+        editable
+      />
+    </div>
+  `,
+})
+
 stories.add('default', withSummary(defaultStory))
 stories.add('password', withSummary(passwordStory))
 stories.add('mask', withSummary(maskStory))
@@ -208,3 +233,4 @@ stories.add('autofocus', withSummary(autofocusStory))
 stories.add('address autocomplete', withSummary(addressAutocompleteStory))
 stories.add('clearable', withSummary(clearableStory))
 stories.add('currency', withSummary(currencyStory))
+stories.add('editable', withSummary(editableStory))

--- a/src/components/FbxTextField/FbxTextField.stories.js
+++ b/src/components/FbxTextField/FbxTextField.stories.js
@@ -235,10 +235,14 @@ const editableStory = () => ({
   data() {
     return {
       inputText: '',
+      inputText2: '',
     }
   },
   watch: {
     inputText(value) {
+      action(`New value`)(value)
+    },
+    inputText2(value) {
       action(`New value`)(value)
     },
   },
@@ -250,6 +254,20 @@ const editableStory = () => ({
         placeholder="Enter a word"
         v-model="inputText"
         editable
+      />
+      <fbx-text-field
+        label="With currency and validations (min $1,000, max $9,999.99)"
+        name="amount"
+        class="input"
+        placeholder="Enter an amount"
+        v-model="inputText2"
+        editable
+        currency
+        :validations="{
+          required: 'true',
+          max_value: 9999.99,
+          min_value: 1000,
+        }"
       />
     </div>
   `,

--- a/src/components/FbxTextField/FbxTextField.vue
+++ b/src/components/FbxTextField/FbxTextField.vue
@@ -22,6 +22,7 @@
             currency: isCurrency,
             editable: editable,
           }"
+          :data-vv-validate-on="validateOnType ? 'input' : 'change'"
           v-validate="validations"
           v-bind="$attrs"
           :value="value"
@@ -139,6 +140,9 @@ export default {
     isCurrency() {
       return this.currency && this.value.length
     },
+    validateOnType() {
+      return this.currency || this.editable
+    }
   },
   methods: {
     togglePassword() {

--- a/src/components/FbxTextField/FbxTextField.vue
+++ b/src/components/FbxTextField/FbxTextField.vue
@@ -10,12 +10,14 @@
           v-mask="mask"
           :type="type"
           tabindex="0"
+          :readonly="showEdit"
           class="fbx-text-field__input"
           :class="{
             password: isPassword,
             invalid: isInvalid,
             clearable: clearable,
             currency: isCurrency,
+            editable: editable,
           }"
           v-validate="validations"
           v-bind="$attrs"
@@ -23,6 +25,14 @@
           v-on="{ input: currency ? onCurrencyInput : onInput }"
           @change="onChange"
         />
+
+        <span class="fbx-text-field__edit" v-if="showEdit" @click="onEdit">Edit</span>
+
+        <div class="fbx-text-field__done-icons" v-if="showDoneIcons">
+          <span class="done-icons__done-icon" @click="onDoneEditing">Done</span>
+          <span class="done-icons__separator">|</span>
+          <span class="done-icons__cancel-icon fbx-icon-x" @click="onCancelEditing"></span>
+        </div>
 
         <span class="fbx-text-field__dollar-sign" v-if="isCurrency">$</span>
 
@@ -58,7 +68,9 @@ export default {
   data() {
     return {
       isPassword: this.$attrs.type === 'password',
-      type: this.$attrs.type || 'text'
+      type: this.$attrs.type || 'text',
+      isEditing: false,
+      valueBeforeEditing: '',
     }
   },
   props: {
@@ -89,6 +101,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    editable: {
+      type: Boolean,
+      default: false,
+    },
   },
   computed: {
     passwordButtonText() {
@@ -103,6 +119,12 @@ export default {
     isCurrency() {
       return this.currency && this.value.length
     },
+    showEdit() {
+      return this.editable && !this.isEditing
+    },
+    showDoneIcons() {
+      return this.editable && this.isEditing
+    },
   },
   methods: {
     togglePassword() {
@@ -111,6 +133,18 @@ export default {
     clearField() {
       this.$refs.fbxTextFieldInput.focus()
       this.$emit('input', '')
+    },
+    onEdit() {
+      this.isEditing = true
+      this.valueBeforeEditing = this.value
+      this.$refs.fbxTextFieldInput.focus()
+    },
+    onDoneEditing() {
+      this.isEditing = false
+    },
+    onCancelEditing() {
+      this.isEditing = false
+      this.$emit('input', this.valueBeforeEditing)
     },
     onCurrencyInput(event) {
       let value = event.target.value
@@ -173,7 +207,8 @@ export default {
       padding-right: 60px;
     }
 
-    &:focus {
+    // Don't show the focus bottom border if input is editable and in readonly mode
+    &:not(:read-only):not(.invalid):focus {
       border-bottom: 1px solid $dark-green;
     }
 
@@ -190,6 +225,10 @@ export default {
       position: relative;
       padding-left: 25px;
     }
+
+    &.editable {
+      padding-right: 95px;
+    }
   }
 
   .fbx-text-field__dollar-sign {
@@ -201,19 +240,49 @@ export default {
     user-select: none;
   }
 
+
+  .fbx-text-field__edit,
+  .fbx-text-field__done-icons,
   .fbx-text-field__password-button,
   .fbx-text-field__clear-icon {
     position: absolute;
     right: 15px;
     top: 50%;
     transform: translateY(-50%);
-    cursor: pointer;
     user-select: none;
   }
 
+  .fbx-text-field__edit,
   .fbx-text-field__password-button {
     @include font(16);
     color: $dark-green;
+    cursor: pointer;
+  }
+
+  .fbx-text-field__done-icons {
+    display: flex;
+    align-items: center;
+    color: $dark-green;
+  }
+
+  .done-icons__done-icon {
+    @include font(14);
+  }
+
+  .done-icons__done-icon,
+  .done-icons__cancel-icon {
+    cursor: pointer;
+  }
+
+  .done-icons__separator {
+    margin: 0 13px;
+    @include font(14);
+    color: $extra-dark-gray;
+  }
+
+  .done-icons__cancel-icon {
+    font-size: 9px;
+    line-height: 21px;
   }
 
   .fbx-text-field__clear-icon {
@@ -222,6 +291,7 @@ export default {
     width: 30px;
     height: 100%;
     color: $medium-blue;
+    cursor: pointer;
     background-repeat: no-repeat;
     background-position: 50% 50%;
     background-size: 12px 10px;

--- a/src/components/FbxTextField/FbxTextField.vue
+++ b/src/components/FbxTextField/FbxTextField.vue
@@ -3,8 +3,6 @@
     <label class="fbx-text-field__label">{{ label }}</label>
     <div class="fbx-text-field__wrapper">
       <div class="fbx-text-field__input-wrapper">
-        <span class="fbx-text-field__dollar-sign" v-if="isCurrency">$</span>
-
         <input
           ref="fbxTextFieldInput"
           v-fbx-address-autocomplete="addressAutocomplete"
@@ -29,6 +27,8 @@
           @input="onInput"
           @change="onChange"
         />
+
+        <span class="fbx-text-field__dollar-sign" v-if="isCurrency">$</span>
 
         <div class="edit-buttons-wrapper" v-if="editable">
           <div class="fbx-text-field__done-icons" v-if="isEditing">

--- a/src/components/FbxTextField/FbxTextField.vue
+++ b/src/components/FbxTextField/FbxTextField.vue
@@ -42,7 +42,7 @@
 
         <span
           class="fbx-text-field__dollar-sign"
-          :class="{ 'is-not-editing': !isEditing }"
+          :class="{ 'is-not-editing': editable && !isEditing }"
           v-if="isCurrency"
         >
           $

--- a/src/components/FbxTextField/FbxTextField.vue
+++ b/src/components/FbxTextField/FbxTextField.vue
@@ -157,7 +157,7 @@ export default {
       this.$emit('input', this.valueBeforeEditing)
       this.$nextTick(() => {
       // Rerun validation on the value that we just rolled back to
-        this.$validator.validate()
+        this.$validator.validate(this.$attrs.name)
       })
     },
     onCurrencyInput(event) {

--- a/src/components/FbxTextField/FbxTextField.vue
+++ b/src/components/FbxTextField/FbxTextField.vue
@@ -145,6 +145,8 @@ export default {
     onCancelEditing() {
       this.isEditing = false
       this.$emit('input', this.valueBeforeEditing)
+      // Rerender so that validation is run again on the value that we just rolled back to
+      this.$forceUpdate()
     },
     onCurrencyInput(event) {
       let value = event.target.value

--- a/src/components/FbxTextField/FbxTextField.vue
+++ b/src/components/FbxTextField/FbxTextField.vue
@@ -152,14 +152,17 @@ export default {
     },
     onEdit() {
       this.isEditing = true
+      this.$emit('editing', true)
       this.valueBeforeEditing = this.value
       this.$refs.fbxTextFieldInput.focus()
     },
     onDoneEditing() {
       this.isEditing = false
+      this.$emit('editing', false)
     },
     onCancelEditing() {
       this.isEditing = false
+      this.$emit('editing', false)
       this.$emit('input', this.valueBeforeEditing)
       this.$nextTick(() => {
       // Rerun validation on the value that we just rolled back to

--- a/src/components/FbxTextField/FbxTextField.vue
+++ b/src/components/FbxTextField/FbxTextField.vue
@@ -161,6 +161,7 @@ export default {
     onDoneEditing() {
       this.isEditing = false
       this.$emit('editing', false)
+      this.$emit('updated')
     },
     onCancelEditing() {
       this.isEditing = false

--- a/src/components/FbxTextField/FbxTextField.vue
+++ b/src/components/FbxTextField/FbxTextField.vue
@@ -35,7 +35,13 @@
           <span class="done-icons__cancel-icon fbx-icon-x" @click="onCancelEditing"></span>
         </div>
 
-        <span class="fbx-text-field__dollar-sign" v-if="isCurrency">$</span>
+        <span
+          class="fbx-text-field__dollar-sign"
+          :class="{ 'is-editing': showEdit }"
+          v-if="isCurrency"
+        >
+          $
+        </span>
 
         <span class="fbx-text-field__password-button" @click="togglePassword" v-if="isPassword">{{ passwordButtonText }}</span>
 
@@ -221,6 +227,10 @@ export default {
       padding-right: 60px;
     }
 
+    &:read-only {
+      color: $extra-dark-gray;
+    }
+
     // Don't show the focus bottom border if input is editable and in readonly mode
     &:not(:read-only):not(.invalid):focus {
       border-bottom: 1px solid $dark-green;
@@ -252,6 +262,10 @@ export default {
     transform: translateY(-50%);
     @include font(16);
     user-select: none;
+
+    &.is-editing {
+      color: $extra-dark-gray;
+    }
   }
 
 

--- a/src/components/FbxTextField/FbxTextField.vue
+++ b/src/components/FbxTextField/FbxTextField.vue
@@ -13,7 +13,7 @@
           v-mask="mask"
           :type="type"
           tabindex="0"
-          :readonly="showEdit"
+          :readonly="editable && !isEditing"
           class="fbx-text-field__input"
           :class="{
             password: isPassword,
@@ -29,17 +29,19 @@
           @change="onChange"
         />
 
-        <span class="fbx-text-field__edit" v-if="showEdit" @click="onEdit">Edit</span>
+        <div class="edit-buttons-wrapper" v-if="editable">
+          <div class="fbx-text-field__done-icons" v-if="isEditing">
+            <span class="done-icons__done-icon" @click="onDoneEditing">Done</span>
+            <span class="done-icons__separator">|</span>
+            <span class="done-icons__cancel-icon fbx-icon-x" @click="onCancelEditing"></span>
+          </div>
 
-        <div class="fbx-text-field__done-icons" v-if="showDoneIcons">
-          <span class="done-icons__done-icon" @click="onDoneEditing">Done</span>
-          <span class="done-icons__separator">|</span>
-          <span class="done-icons__cancel-icon fbx-icon-x" @click="onCancelEditing"></span>
+          <span class="fbx-text-field__edit" v-else @click="onEdit">Edit</span>
         </div>
 
         <span
           class="fbx-text-field__dollar-sign"
-          :class="{ 'is-editing': showEdit }"
+          :class="{ 'is-not-editing': !isEditing }"
           v-if="isCurrency"
         >
           $
@@ -136,12 +138,6 @@ export default {
     },
     isCurrency() {
       return this.currency && this.value.length
-    },
-    showEdit() {
-      return this.editable && !this.isEditing
-    },
-    showDoneIcons() {
-      return this.editable && this.isEditing
     },
   },
   methods: {
@@ -270,7 +266,7 @@ export default {
     user-select: none;
     z-index: 1;
 
-    &.is-editing {
+    &.is-not-editing {
       color: $extra-dark-gray;
     }
   }

--- a/src/components/FbxTextField/FbxTextField.vue
+++ b/src/components/FbxTextField/FbxTextField.vue
@@ -155,8 +155,10 @@ export default {
     onCancelEditing() {
       this.isEditing = false
       this.$emit('input', this.valueBeforeEditing)
-      // Rerender so that validation is run again on the value that we just rolled back to
-      this.$forceUpdate()
+      this.$nextTick(() => {
+      // Rerun validation on the value that we just rolled back to
+        this.$validator.validate()
+      })
     },
     onCurrencyInput(event) {
       let value = event.target.value

--- a/src/components/FbxTextField/__snapshots__/FbxTextField.spec.js.snap
+++ b/src/components/FbxTextField/__snapshots__/FbxTextField.spec.js.snap
@@ -16,8 +16,7 @@ exports[`FbxTextField snapshots renders clear icon 1`] = `
 <div class="fbx-text-field"><label class="fbx-text-field__label"></label>
   <div class="fbx-text-field__wrapper">
     <div class="fbx-text-field__input-wrapper">
-      <!----> <input type="text" tabindex="0" name="my-input" class="fbx-text-field__input clearable" data-mask="" data-previous-value="avocado" aria-required="false" aria-invalid="false">
-      <!---->
+      <!----> <input type="text" tabindex="0" data-vv-validate-on="change" name="my-input" class="fbx-text-field__input clearable" data-mask="" data-previous-value="avocado" aria-required="false" aria-invalid="false">
       <!---->
       <!---->
       <!----> <span class="fbx-text-field__clear-icon"></span></div>
@@ -30,8 +29,7 @@ exports[`FbxTextField snapshots renders the default 1`] = `
 <div class="fbx-text-field"><label class="fbx-text-field__label">Favorite Food</label>
   <div class="fbx-text-field__wrapper">
     <div class="fbx-text-field__input-wrapper">
-      <!----> <input type="text" tabindex="0" name="my-input" class="fbx-text-field__input" data-mask="" data-previous-value="avocado" aria-required="false" aria-invalid="false">
-      <!---->
+      <!----> <input type="text" tabindex="0" data-vv-validate-on="change" name="my-input" class="fbx-text-field__input" data-mask="" data-previous-value="avocado" aria-required="false" aria-invalid="false">
       <!---->
       <!---->
       <!---->

--- a/src/components/FbxTextField/__snapshots__/FbxTextField.spec.js.snap
+++ b/src/components/FbxTextField/__snapshots__/FbxTextField.spec.js.snap
@@ -3,7 +3,10 @@
 exports[`FbxTextField snapshots renders a currency mask 1`] = `
 <div class="fbx-text-field"><label class="fbx-text-field__label"></label>
   <div class="fbx-text-field__wrapper">
-    <div class="fbx-text-field__input-wrapper"><input type="text" tabindex="0" name="my-input" class="fbx-text-field__input currency" data-mask="" data-previous-value="12879.25" aria-required="false" aria-invalid="false"> <span class="fbx-text-field__dollar-sign">$</span>
+    <div class="fbx-text-field__input-wrapper"><input type="text" tabindex="0" data-vv-validate-on="input" name="my-input" class="fbx-text-field__input currency" data-mask="" data-previous-value="12879.25" aria-required="false" aria-invalid="false"> <span class="fbx-text-field__dollar-sign">$</span>
+      <!----> <span class="fbx-text-field__dollar-sign">
+        $
+      </span>
       <!---->
       <!---->
     </div>
@@ -15,8 +18,8 @@ exports[`FbxTextField snapshots renders a currency mask 1`] = `
 exports[`FbxTextField snapshots renders clear icon 1`] = `
 <div class="fbx-text-field"><label class="fbx-text-field__label"></label>
   <div class="fbx-text-field__wrapper">
-    <div class="fbx-text-field__input-wrapper">
-      <!----> <input type="text" tabindex="0" data-vv-validate-on="change" name="my-input" class="fbx-text-field__input clearable" data-mask="" data-previous-value="avocado" aria-required="false" aria-invalid="false">
+    <div class="fbx-text-field__input-wrapper"><input type="text" tabindex="0" data-vv-validate-on="change" name="my-input" class="fbx-text-field__input clearable" data-mask="" data-previous-value="avocado" aria-required="false" aria-invalid="false">
+      <!---->
       <!---->
       <!---->
       <!----> <span class="fbx-text-field__clear-icon"></span></div>
@@ -28,8 +31,8 @@ exports[`FbxTextField snapshots renders clear icon 1`] = `
 exports[`FbxTextField snapshots renders the default 1`] = `
 <div class="fbx-text-field"><label class="fbx-text-field__label">Favorite Food</label>
   <div class="fbx-text-field__wrapper">
-    <div class="fbx-text-field__input-wrapper">
-      <!----> <input type="text" tabindex="0" data-vv-validate-on="change" name="my-input" class="fbx-text-field__input" data-mask="" data-previous-value="avocado" aria-required="false" aria-invalid="false">
+    <div class="fbx-text-field__input-wrapper"><input type="text" tabindex="0" data-vv-validate-on="change" name="my-input" class="fbx-text-field__input" data-mask="" data-previous-value="avocado" aria-required="false" aria-invalid="false">
+      <!---->
       <!---->
       <!---->
       <!---->

--- a/src/components/FbxTextField/__snapshots__/FbxTextField.spec.js.snap
+++ b/src/components/FbxTextField/__snapshots__/FbxTextField.spec.js.snap
@@ -17,14 +17,9 @@ exports[`FbxTextField snapshots renders clear icon 1`] = `
   <div class="fbx-text-field__wrapper">
     <div class="fbx-text-field__input-wrapper">
       <!----> <input type="text" tabindex="0" name="my-input" class="fbx-text-field__input clearable" data-mask="" data-previous-value="avocado" aria-required="false" aria-invalid="false">
-
-      &lt;&lt;&lt;&lt;&lt;&lt;&lt; HEAD
       <!---->
       <!---->
       <!---->
-
-      =======
-      &gt;&gt;&gt;&gt;&gt;&gt;&gt; P1-865-currency-field
       <!----> <span class="fbx-text-field__clear-icon"></span></div>
     <!---->
   </div>
@@ -36,14 +31,9 @@ exports[`FbxTextField snapshots renders the default 1`] = `
   <div class="fbx-text-field__wrapper">
     <div class="fbx-text-field__input-wrapper">
       <!----> <input type="text" tabindex="0" name="my-input" class="fbx-text-field__input" data-mask="" data-previous-value="avocado" aria-required="false" aria-invalid="false">
-
-      &lt;&lt;&lt;&lt;&lt;&lt;&lt; HEAD
       <!---->
       <!---->
       <!---->
-
-      =======
-      &gt;&gt;&gt;&gt;&gt;&gt;&gt; P1-865-currency-field
       <!---->
       <!---->
     </div>

--- a/src/components/FbxTextField/__snapshots__/FbxTextField.spec.js.snap
+++ b/src/components/FbxTextField/__snapshots__/FbxTextField.spec.js.snap
@@ -17,6 +17,8 @@ exports[`FbxTextField snapshots renders clear icon 1`] = `
   <div class="fbx-text-field__wrapper">
     <div class="fbx-text-field__input-wrapper"><input type="text" tabindex="0" name="my-input" class="fbx-text-field__input clearable" data-mask="" data-previous-value="avocado" aria-required="false" aria-invalid="false">
       <!---->
+      <!---->
+      <!---->
       <!----> <span class="fbx-text-field__clear-icon"></span></div>
     <!---->
   </div>
@@ -27,6 +29,8 @@ exports[`FbxTextField snapshots renders the default 1`] = `
 <div class="fbx-text-field"><label class="fbx-text-field__label">Favorite Food</label>
   <div class="fbx-text-field__wrapper">
     <div class="fbx-text-field__input-wrapper"><input type="text" tabindex="0" name="my-input" class="fbx-text-field__input" data-mask="" data-previous-value="avocado" aria-required="false" aria-invalid="false">
+      <!---->
+      <!---->
       <!---->
       <!---->
       <!---->

--- a/src/icons/Icomoon/Icomoon.scss
+++ b/src/icons/Icomoon/Icomoon.scss
@@ -1,6 +1,11 @@
 .icon-story-wrapper {
   display: flex;
   flex-wrap: wrap;
+
+  & [class^="fbx-icon-"],
+  & [class*=" fbx-icon-"] {
+    margin-right: 20px;
+  }
 }
 
 .icon-description-wrapper {
@@ -8,8 +13,4 @@
   align-items: center;
   width: 50%;
   padding: 10px;
-}
-
-[class^="fbx-icon-"], [class*=" fbx-icon-"] {
-  margin-right: 20px;
 }

--- a/src/icons/Icomoon/Icomoon.scss
+++ b/src/icons/Icomoon/Icomoon.scss
@@ -1,0 +1,15 @@
+.icon-story-wrapper {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.icon-description-wrapper {
+  display: flex;
+  align-items: center;
+  width: 50%;
+  padding: 10px;
+}
+
+[class^="fbx-icon-"], [class*=" fbx-icon-"] {
+  margin-right: 20px;
+}

--- a/src/icons/Icomoon/Icomoon.stories.js
+++ b/src/icons/Icomoon/Icomoon.stories.js
@@ -1,0 +1,149 @@
+import { storiesOf } from '@storybook/vue'
+import './Icomoon.scss'
+
+const stories = storiesOf('Icons/Icomoon', module)
+
+const defaultStory = () => ({
+  template: `
+    <div class="icon-story-wrapper">
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-32_round_X"></div>
+        <div class="icon-description">fbx-icon-32_round_X</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-32_round_question"></div>
+        <div class="icon-description">fbx-icon-32_round_question</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-32_badge_check_mark"></div>
+        <div class="icon-description">fbx-icon-32_badge_check_mark</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-24_arrow-down"></div>
+        <div class="icon-description">fbx-icon-24_arrow-down</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-24_arrow-left"></div>
+        <div class="icon-description">fbx-icon-24_arrow-left</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-24_arrow-right"></div>
+        <div class="icon-description">fbx-icon-24_arrow-right</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-24_check"></div>
+        <div class="icon-description">fbx-icon-24_check</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-24_checkmark-in-circle"></div>
+        <div class="icon-description">fbx-icon-24_checkmark-in-circle</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-24_close_hover"></div>
+        <div class="icon-description">fbx-icon-24_close_hover</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-24_close"></div>
+        <div class="icon-description">fbx-icon-24_close</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-24_lock"></div>
+        <div class="icon-description">fbx-icon-24_lock</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-24_warning-triangle"></div>
+        <div class="icon-description">fbx-icon-24_warning-triangle</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-24_x-alerts"></div>
+        <div class="icon-description">fbx-icon-24_x-alerts</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-green-checkmark-in-circle"></div>
+        <div class="icon-description">fbx-icon-green-checkmark-in-circle</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-add"></div>
+        <div class="icon-description">fbx-icon-add</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-warning-triangle2"></div>
+        <div class="icon-description">fbx-icon-warning-triangle2</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-lock"></div>
+        <div class="icon-description">fbx-icon-lock</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-x-alerts"></div>
+        <div class="icon-description">fbx-icon-x-alerts</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-close"></div>
+        <div class="icon-description">fbx-icon-close</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-arrow-down"></div>
+        <div class="icon-description">fbx-icon-arrow-down</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-arrow-left"></div>
+        <div class="icon-description">fbx-icon-arrow-left</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-arrow-right"></div>
+        <div class="icon-description">fbx-icon-arrow-right</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-check"></div>
+        <div class="icon-description">fbx-icon-check</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-printer"></div>
+        <div class="icon-description">fbx-icon-printer</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-warning-triangle"></div>
+        <div class="icon-description">fbx-icon-warning-triangle</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-x"></div>
+        <div class="icon-description">fbx-icon-x</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-24_thumbs-down"></div>
+        <div class="icon-description">fbx-icon-24_thumbs-down</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-24_thumbs-up"></div>
+        <div class="icon-description">fbx-icon-24_thumbs-up</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-24_lightbulb-on"></div>
+        <div class="icon-description">fbx-icon-24_lightbulb-on</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-24_lightbulb-off"></div>
+        <div class="icon-description">fbx-icon-24_lightbulb-off</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-16_document"></div>
+        <div class="icon-description">fbx-icon-16_document</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-16_pencil"></div>
+        <div class="icon-description">fbx-icon-16_pencil</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-16_plus"></div>
+        <div class="icon-description">fbx-icon-16_plus</div>
+      </div>
+      <div class="icon-description-wrapper">
+        <div class="fbx-icon-16_switch"></div>
+        <div class="icon-description">fbx-icon-16_switch</div>
+      </div>
+    </div>
+  `,
+})
+
+stories.add('default', defaultStory)

--- a/src/icons/index.js
+++ b/src/icons/index.js
@@ -1,0 +1,5 @@
+import Icomoon from './Icomoon'
+
+export {
+  Icomoon,
+}

--- a/src/main.stories.js
+++ b/src/main.stories.js
@@ -1,5 +1,8 @@
 /* eslint-disable no-unused-vars */
 
+// Icons
+import Icomoon from './icons/Icomoon/Icomoon.stories.js'
+
 // Components
 import FbxNotice from './components/FbxNotice/FbxNotice.stories.js'
 import FbxIosSwitchButton from './components/FbxIosSwitchButton/FbxIosSwitchButton.stories.js'


### PR DESCRIPTION
### Description

Adding the ability for `FbxTextField` to be "editable". This means that it will be in `readonly` mode until you select the `Edit` button. Once you're done typing, you can select `Done`, or you have the option to rollback to the previous value by clicking the `X`.



PR Resources | Links
------ | ------
🎫 Ticket | [P1-865](https://fundbox.atlassian.net/browse/P1-865)

### Todos

- [x] Add section for displaying icomoon icons
- [x] Make input editable
- [x] Handle clicking `Done`
- [x] Handle rolling back to the previous value when clicking `X`
- [x] Handle validations
- [x] Handle working with the `currency` mask

### Preview
Note: CSS my slightly change

<img src="https://user-images.githubusercontent.com/5829188/55521631-6426d500-5636-11e9-8077-49ab73b2a429.png" width="350px"/>

<img src="https://user-images.githubusercontent.com/5829188/55521729-ca135c80-5636-11e9-8123-765b484ee55b.png" width="350px"/>


