### PR TITLE
Update copy for the FbxTextField "done" button after editing

### DIFF
--- a/src/components/FbxTextField/FbxTextField.spec.js
+++ b/src/components/FbxTextField/FbxTextField.spec.js
@@ -47,6 +47,35 @@ describe('FbxTextField', () => {
 
       expect(wrapper.html()).toMatchSnapshot()
     })
+
+    it('renders an edit button', () => {
+      const wrapper = shallowMount(FbxTextField, {
+        sync: false,
+        propsData: {
+          name: 'my-input',
+          value: 'hello',
+          editable: true,
+        },
+      })
+
+      expect(wrapper.html()).toMatchSnapshot()
+    })
+
+    it('renders save and clear buttons', () => {
+      const wrapper = shallowMount(FbxTextField, {
+        sync: false,
+        propsData: {
+          name: 'my-input',
+          value: 'hello',
+          editable: true,
+        },
+      })
+      wrapper.find('span').trigger('click')
+
+      wrapper.vm.$nextTick(() => {
+        expect(wrapper.html()).toMatchSnapshot()
+      })
+    })
   })
 
   describe('methods', () => {

--- a/src/components/FbxTextField/FbxTextField.vue
+++ b/src/components/FbxTextField/FbxTextField.vue
@@ -32,7 +32,7 @@
 
         <div class="edit-buttons-wrapper" v-if="editable">
           <div class="fbx-text-field__done-icons" v-if="isEditing">
-            <span class="done-icons__done-icon" @click="onDoneEditing">Done</span>
+            <span class="done-icons__done-icon" @click="onDoneEditing">Save</span>
             <span class="done-icons__separator">|</span>
             <span class="done-icons__cancel-icon fbx-icon-x" @click="onCancelEditing"></span>
           </div>

--- a/src/components/FbxTextField/__snapshots__/FbxTextField.spec.js.snap
+++ b/src/components/FbxTextField/__snapshots__/FbxTextField.spec.js.snap
@@ -15,6 +15,21 @@ exports[`FbxTextField snapshots renders a currency mask 1`] = `
 </div>
 `;
 
+exports[`FbxTextField snapshots renders an edit button 1`] = `
+<div class="fbx-text-field"><label class="fbx-text-field__label"></label>
+  <div class="fbx-text-field__wrapper">
+    <div class="fbx-text-field__input-wrapper"><input type="text" tabindex="0" readonly="readonly" data-vv-validate-on="input" name="my-input" class="fbx-text-field__input editable" data-mask="" data-previous-value="hello" aria-required="false" aria-invalid="false">
+      <!---->
+      <div class="edit-buttons-wrapper"><span class="fbx-text-field__edit">Edit</span></div>
+      <!---->
+      <!---->
+      <!---->
+    </div>
+    <!---->
+  </div>
+</div>
+`;
+
 exports[`FbxTextField snapshots renders clear icon 1`] = `
 <div class="fbx-text-field"><label class="fbx-text-field__label"></label>
   <div class="fbx-text-field__wrapper">
@@ -23,6 +38,23 @@ exports[`FbxTextField snapshots renders clear icon 1`] = `
       <!---->
       <!---->
       <!----> <span class="fbx-text-field__clear-icon"></span></div>
+    <!---->
+  </div>
+</div>
+`;
+
+exports[`FbxTextField snapshots renders save and clear buttons 1`] = `
+<div class="fbx-text-field"><label class="fbx-text-field__label"></label>
+  <div class="fbx-text-field__wrapper">
+    <div class="fbx-text-field__input-wrapper"><input type="text" tabindex="0" data-vv-validate-on="input" name="my-input" class="fbx-text-field__input editable" data-mask="" data-previous-value="hello" aria-required="false" aria-invalid="false">
+      <!---->
+      <div class="edit-buttons-wrapper">
+        <div class="fbx-text-field__done-icons"><span class="done-icons__done-icon">Save</span> <span class="done-icons__separator">|</span> <span class="done-icons__cancel-icon fbx-icon-x"></span></div>
+      </div>
+      <!---->
+      <!---->
+      <!---->
+    </div>
     <!---->
   </div>
 </div>


### PR DESCRIPTION
### Description

The `FbxTextField` component has an `editable` option, which shows an edit button in the input, after you edit the value, you need to select one of the following: `Done | X`. Design asked to change `Done` to `Save`

<img src="https://user-images.githubusercontent.com/5829188/56252378-5d538580-606c-11e9-9fb5-e70ca5b48452.png" width="400px"/>
