### PR TITLE
fix(TileGrid): Fix tile height

### DIFF
--- a/src/components/FbxTileGrid/FbxTileGrid.vue
+++ b/src/components/FbxTileGrid/FbxTileGrid.vue
@@ -86,7 +86,7 @@ export default {
 
   .tile-wrapper {
     padding: 0 $horizontal-spacing $vertical-spacing 0;
-    height: $height;
+    height: $height + $vertical-spacing;
     position: relative;
     flex-shrink: 0;
     flex-grow: 0;


### PR DESCRIPTION
### Description
The desired height is 75px. But the content rendered at 65px because of vertical padding.
I've added the two together so the actual height would always be correct.


PR Resources | Links
------ | ------
🎫 Ticket | [ACTIVE-671](https://fundbox.atlassian.net/browse/ACTIVE-671)