### PR TITLE
fix(components): fix select component events issue

### DIFF
--- a/src/components/FbxSelect/FbxSelect.spec.js
+++ b/src/components/FbxSelect/FbxSelect.spec.js
@@ -4,10 +4,12 @@ import VeeValidate from 'vee-validate'
 import FbxSelect from './FbxSelect.vue'
 
 const option1 = 'Option 1'
+const option2 = 'Option 2'
 const defaultSlot = {
   default: `
     <option>Default</option>
     <option value="${option1}">${option1}</option>
+    <option value="${option2}">${option2}</option>
   `
 }
 
@@ -82,21 +84,30 @@ describe('FbxSelect', () => {
   describe('events', () => {
     it('calls input event with selected value on value select', () => {
       const mockInput = jest.fn()
+      const mockChange = jest.fn()
       const wrapper = shallowMount(FbxSelect, {
         slots: defaultSlot,
         attrs: {
           name: 'select'
         },
         listeners: {
+          change: mockChange,
           input: mockInput,
         },
         sync: false,
         localVue
       })
-      const options = wrapper.find('select').findAll('option')
+      const selectWrapper = wrapper.find('select')
+      const options = selectWrapper.findAll('option')
+
       options.at(1).setSelected()
+      expect(mockChange).toHaveBeenCalledTimes(1)
+      expect(mockChange).toHaveBeenCalledWith(option1)
+
+      options.at(2).element.selected = true
+      options.at(2).trigger('input')
       expect(mockInput).toHaveBeenCalledTimes(1)
-      expect(mockInput).toHaveBeenCalledWith(option1)
+      expect(mockInput).toHaveBeenCalledWith(option2)
     })
 
     it('calls regular events of select', () => {

--- a/src/components/FbxSelect/FbxSelect.vue
+++ b/src/components/FbxSelect/FbxSelect.vue
@@ -38,9 +38,12 @@ export default {
       return {
         // Pass all component listeners directly to button
         ...this.$listeners,
-        change: ({ target }) => {
+        input: ({ target }) => {
           this.$emit('input', target.value)
-        }
+        },
+        change: ({ target }) => {
+          this.$emit('change', target.value)
+        },
       }
     }
   }

--- a/src/components/FbxSelect/__snapshots__/FbxSelect.spec.js.snap
+++ b/src/components/FbxSelect/__snapshots__/FbxSelect.spec.js.snap
@@ -4,6 +4,7 @@ exports[`FbxSelect snapshots renders the default correctly 1`] = `
 <div><select name="select" class="fbx-select" aria-required="false" aria-invalid="false">
     <option>Default</option>
     <option value="Option 1">Option 1</option>
+    <option value="Option 2">Option 2</option>
   </select>
   <!---->
 </div>
@@ -13,6 +14,7 @@ exports[`FbxSelect snapshots renders validations correctly 1`] = `
 <div><select name="select" class="fbx-select invalid" aria-required="false" aria-invalid="false">
     <option>Default</option>
     <option value="Option 1">Option 1</option>
+    <option value="Option 2">Option 2</option>
   </select>
   <fbx-validation-message-stub class="validation-message">This field is required</fbx-validation-message-stub>
 </div>


### PR DESCRIPTION
### Description

There was a problem with the input event. Its value was `Event` type instead of `String` as defined in props. 


### Todos

- [X] Updated and added unit tests
